### PR TITLE
Make cloning of rpc repository recursive

### DIFF
--- a/deploy-rpc.sh
+++ b/deploy-rpc.sh
@@ -25,7 +25,7 @@ ssh_agent_reset
 apt-get install -y git tmux
 
 # Clone the RPC source code
-git clone ${RPC_REPO} /opt/rpc-openstack || true
+git clone --recursive ${RPC_REPO} /opt/rpc-openstack || true
 
 # Ensure the "/etc/openstack_deploy" exists
 mkdir_check "/etc/openstack_deploy"


### PR DESCRIPTION
This fix makes it so that the OSA repo is actually cloned in
with the RPC repo. Previously it did not do this and caused
errors down the line.
