### PR TITLE
Fixed conditional and directory issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,8 +47,8 @@ SETUP_VIRSH_NET=${SETUP_VIRSH_NET:-true}
 DEPLOY_VMS=${DEPLOY_VMS:-true}
 [[ "${DEPLOY_VMS}" = true ]] && source deploy-vms.sh
 
-if [ "${DEPLOY_OSA}" = true ]; then
+if [ "${DEPLOY_OSA}" = "yes" ]; then
     source deploy-osa.sh
-elif [ "${DEPLOY_RPC}" = true ]; then
+elif [ "${DEPLOY_RPC}" = "yes" ]; then
     source deploy-rpc.sh
 fi

--- a/deploy-rpc.sh
+++ b/deploy-rpc.sh
@@ -38,7 +38,7 @@ pushd /opt/rpc-openstack
   git checkout "${RPC_BRANCH:-master}"
 
   # Copy the etc files into place
-  cp -r /opt/rpc-openstack/openstack-ansible/etc/openstack_deploy /etc/openstack_deploy/
+  cp -r /opt/rpc-openstack/openstack-ansible/etc/openstack_deploy /etc
   
   # Merge rpc user_variables
   /opt/rpc-openstack/scripts/update-yaml.py \


### PR DESCRIPTION
Fixed the issue where testing for true is not the same as testing
for yes in build.sh at the end of the script when deciding which
deploy script to run. Previously it would just exit without
running either.

Fixed the directory issue in deploy-rpc.sh where it would copy
openstack_deploy into /etc/openstack_deploy/openstack_deploy
instead of /etc/openstack_deploy where it belongs.
